### PR TITLE
Revert "Bump mysql-connector-java from 5.1.39 to 8.0.16"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.16</version>
+      <version>5.1.39</version>
     </dependency>
     <dependency>
       <groupId>org.apache.derby</groupId>


### PR DESCRIPTION
Reverts LaudemPax/ATSAutoPOS#3

Maintain legacy MYSQL version